### PR TITLE
Fix package installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ pydocstyle = "^6.0"
 pycodestyle = "^2.7"
 mypy = "0.812"
 
+[tool.poetry.scripts]
+templtest = 'rttptool.cli:main'
+
 [tool.pylint."MESSAGES CONTROL"]
 disable = [
     # prefer pycodestyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ license = "MIT"
 python = "^3.6"
 Jinja2 = "^2.11"
 packaging = "^20.9"
+PyYAML = "^5.4"
 
 [tool.poetry.dev-dependencies]
 importlib_resources = { version = "^5.1", python = "<3.7" }
-PyYAML = "^5.4"
 pylint = "^2.8"
 pydocstyle = "^6.0"
 pycodestyle = "^2.7"


### PR DESCRIPTION
Now the package may be installed with `pip`. `templtest` utility is installed to perform tests.