### PR TITLE
Rename specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Ansible Role Templates Testing
-==============================
+templtest
+=========
 
-[Ansible][Ansible] is a tool for automation of software deployment and
+[Ansible&reg;][Ansible] is a tool for automation of software deployment and
 configuration management. Ansible uses [Jinja][Jinja] templates to manage
 configuration files. Development of complex templates requires testing tools.
 
@@ -19,3 +19,6 @@ See [Ansible Role Templates Testing Specification][Spec] for details.
 [Ansible]: https://github.com/ansible/ansible
 [Jinja]: https://jinja.palletsprojects.com/
 [Spec]: doc/specification.md
+
+Ansible is a registered trademark of Red Hat, Inc. in the United States and
+other countries.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
-Role Templates Testing Protocol (RTTP)
-======================================
+Ansible Role Templates Testing
+==============================
 
 [Ansible][Ansible] is a tool for automation of software deployment and
 configuration management. Ansible uses [Jinja][Jinja] templates to manage
 configuration files. Development of complex templates requires testing tools.
 
+`templtest` is a tool for testing templates used by Ansible roles. Put your
+tests in role's `templates_tests/` directory according to the
+[specification][Spec] and run:
+
+```sh
+cd $ROLE_PATH
+templtest
+```
+
+See [Ansible Role Templates Testing Specification][Spec] for details.
+
 [Ansible]: https://github.com/ansible/ansible
 [Jinja]: https://jinja.palletsprojects.com/
-
-This project contains:
-
-* [Role Templates Testing Protocol (RTTP) specification](doc/specification.md)
-* `templtest` -- RTTP reference implementation
+[Spec]: doc/specification.md

--- a/doc/specification.md
+++ b/doc/specification.md
@@ -1,5 +1,5 @@
-Role Templates Testing Protocol (RTTP) Specification
-====================================================
+Ansible Role Templates Testing Specification
+============================================
 
 Version 0.1
 
@@ -30,8 +30,8 @@ development of interoperable test runners that implement the described apporach.
 [Jinja]: https://jinja.palletsprojects.com/
 [Molecule]: https://github.com/ansible-community/molecule
 
-Protocol Operation
-------------------
+Test Runner Operation
+---------------------
 
 This specfication assumes that the tested templates are located in the
 `templates/` subdirectory of an Ansible role directory.

--- a/doc/specification.md
+++ b/doc/specification.md
@@ -1,12 +1,12 @@
-Ansible Role Templates Testing Specification
-============================================
+Ansible&reg; Role Templates Testing Specification
+=================================================
 
 Version 0.1
 
 Introduction
 ------------
 
-[Ansible][Ansible] is a tool for automation of software deployment and
+[Ansible&reg;][Ansible] is a tool for automation of software deployment and
 configuration management. Ansible uses [Jinja][Jinja] templates to manage
 configuration files. Development of complex templates requires testing tools.
 
@@ -213,3 +213,6 @@ This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License. To view a copy of this license, visit
 http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to Creative
 Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+Ansible is a registered trademark of Red Hat, Inc. in the United States and
+other countries.

--- a/doc/specification.md
+++ b/doc/specification.md
@@ -21,7 +21,7 @@ creates and provisions a new container or virtual machine before each test
 scenario. This test setup process is too slow and CPU/memory consuming to run
 many short and simple template tests.
 
-This document defines a protocol for testing Ansible templates. The testing
+This document defines a specification for testing Ansible templates. The testing
 approach, that lacks the above limitations of the existing tools, is described.
 The specification of test definitions is provided in order to facilitate the
 development of interoperable test runners that implement the described apporach.
@@ -68,8 +68,7 @@ directory.
 
 The `templates_tests/` directory must contain `meta.yml` file. This file is a
 YAML document with a single `version` attribute. This attribue specifies a
-version of the test protocol specification. The version of the current
-specification is 0.1.
+version of the specification. The version of the current specification is 0.1.
 
 In order to facilitate an automated test discovery, test definition file names
 have to match a common pattern. This specification defines it as `test*.yml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "templtest"
 version = "0.1.0"
-description = "Role Templates Testing Protocol (RTTP) reference inplementation."
+description = "A tool for testing Ansible role templates."
 authors = ["Alexey Busygin <yaabusygin@gmail.com>"]
 license = "MIT"
 

--- a/templtest/discovery.py
+++ b/templtest/discovery.py
@@ -7,7 +7,7 @@ from yaml import safe_load, YAMLError
 from .exception import TestDefinitionError
 
 
-SUPPORTED_RTTP_VERSION = "0.1"
+SUPPORTED_SPEC_VERSION = "0.1"
 
 
 class Meta(NamedTuple):
@@ -23,12 +23,14 @@ class Meta(NamedTuple):
         try:
             version_string = document["version"]
         except KeyError as exc:
-            raise TestDefinitionError("RTTP version is not specified") from exc
+            msg = "testing speification version is not specified"
+            raise TestDefinitionError(msg) from exc
 
         try:
             version = Version(version_string)
         except (InvalidVersion, TypeError) as exc:
-            raise TestDefinitionError("invalid RTTP version") from exc
+            msg = "invalid testing speification version"
+            raise TestDefinitionError(msg) from exc
 
         return cls(version)
 
@@ -217,8 +219,8 @@ def discover_tests(base_path: Path = Path("templates_tests")) \
         msg = "failed to get tests metadata"
         raise TestDefinitionError(msg) from exc
 
-    if meta.version != Version(SUPPORTED_RTTP_VERSION):
-        msg = "unsupported RTTP version"
+    if meta.version != Version(SUPPORTED_SPEC_VERSION):
+        msg = "unsupported testing speification version"
         raise TestDefinitionError(msg)
 
     for path in _find(base_path, "**/test*.yml"):

--- a/tests/templtest/discovery/test_Meta.py
+++ b/tests/templtest/discovery/test_Meta.py
@@ -107,7 +107,7 @@ class LoadTestMeta(TestCase):
                 Meta.load(base_path=tmpdir_path)
 
             actual = ctxmgr.exception.args[0]
-            expect = "RTTP version is not specified"
+            expect = "testing speification version is not specified"
             self.assertEqual(expect, actual)
 
     def test_invalid_version_1(self):
@@ -126,7 +126,7 @@ class LoadTestMeta(TestCase):
                 Meta.load(base_path=tmpdir_path)
 
             actual = ctxmgr.exception.args[0]
-            expect = "invalid RTTP version"
+            expect = "invalid testing speification version"
             self.assertEqual(expect, actual)
 
     def test_invalid_version_2(self):
@@ -145,5 +145,5 @@ class LoadTestMeta(TestCase):
                 Meta.load(base_path=tmpdir_path)
 
             actual = ctxmgr.exception.args[0]
-            expect = "invalid RTTP version"
+            expect = "invalid testing speification version"
             self.assertEqual(expect, actual)

--- a/tests/templtest/discovery/test_discover_tests.py
+++ b/tests/templtest/discovery/test_discover_tests.py
@@ -112,5 +112,5 @@ class DiscoverTests(TestCase):
             with self.assertRaises(TestDefinitionError) as ctxmgr:
                 next(discover_tests(tests_path))
             actual = ctxmgr.exception.args[0]
-            expect = "unsupported RTTP version"
+            expect = "unsupported testing speification version"
             self.assertEqual(expect, actual)


### PR DESCRIPTION
- Avoid using RTTP abbreviation and "protocol" term.
- Fix trademarks.