### PR TITLE
Fix license specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "templtest"
 version = "0.1.0"
 description = "A tool for testing Ansible role templates."
 authors = ["Alexey Busygin <yaabusygin@gmail.com>"]
-license = "MIT"
+license = "GPLv3+"
 
 [tool.poetry.dependencies]
 python = "^3.6"


### PR DESCRIPTION
The GPL v3 license has been applied to templtest (see #8), but the license specifier in `pyproject.toml` has been leaved with the old value.