### PR TITLE
Add Python 3.10 and 3.11 to CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.10"
+          - "3.11"
     steps:
       - name: check-out repository
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
CI test workflow runs unit tests with Python 3.7-3.11.