### PR TITLE
Update CI workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: "3.9"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: set up Python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: install Poetry
         run: curl --silent --show-error --location https://install.python-poetry.org | python -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check-out repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.3.0
 
       - name: set up Python
         uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - "3.11"
     steps:
       - name: check-out repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3.3.0
 
       - name: set up Python
         uses: actions/setup-python@v2.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: set up Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
- Use actions/checkout version 3.3.0.
- Use actions/setup-python version 4.5.0.
- Use Python 3.11 to publish package to PyPI.