### PR TITLE
Refactor mypy settings

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -13,7 +13,7 @@ trap exit_status_hook EXIT
 PACKAGES="templtest tests"
 
 echo "Running mypy..."
-mypy $PACKAGES
+mypy --non-interactive $PACKAGES
 
 echo "Running pylint..."
 pylint --redefining-builtins-modules=sys $PACKAGES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ mypy = "0.991"
 [tool.poetry.scripts]
 templtest = "templtest.cli:main"
 
+[[tool.mypy.overrides]]
+module = "ansible.*"
+ignore_missing_imports = true
+
 [tool.pylint."MESSAGES CONTROL"]
 disable = [
     # prefer pycodestyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ templtest = "templtest.cli:main"
 module = "ansible.*"
 ignore_missing_imports = true
 
+[tool.mypy]
+install_types = true
+
 [tool.pylint."MESSAGES CONTROL"]
 disable = [
     # prefer pycodestyle

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,6 @@
 [mypy-ansible.*]
 ignore_missing_imports = True
 
-[mypy-yaml.*]
-ignore_missing_imports = True
-
 [pycodestyle]
 max-doc-length = 72
 ignore = E112,  # expected an indented block (prefer mypy)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,5 @@
 [mypy]
 
-[mypy-importlib_resources.*]
-ignore_missing_imports = True
-
 [mypy-ansible.*]
 ignore_missing_imports = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[mypy]
-
-[mypy-ansible.*]
-ignore_missing_imports = True
-
 [pycodestyle]
 max-doc-length = 72
 ignore = E112,  # expected an indented block (prefer mypy)


### PR DESCRIPTION
- Remove unused "remove_missing_imports".
- Move settings to `pyproject.toml`.
- Fix installation python/typeshed stubs for third party packages.