### PR TITLE
Move pydocstyle settings from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,13 @@ disable = [
     "duplicate-code"
 ]
 
+[tool.pydocstyle]
+ignore = [
+    "D1",       # missing docstrings
+    "D203",     # 1 blank line required before class docstring
+    "D213"      # multi-line docstring summary should start at the second line
+]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,3 @@ ignore = E112,  # expected an indented block (prefer mypy)
          E133,  # closing bracket is missing indentation
          E226,  # missing whitespace around arithmetic operator
          W503   # line break before binary operator
-
-[pydocstyle]
-ignore = D1,    # missing docstrings
-         D203,  # 1 blank line required before class docstring
-         D213   # Multi-line docstring summary should start at the second line


### PR DESCRIPTION
Move "pydocstyle" linter settings from `setup.cfg` to `pyproject.toml`.