### PR TITLE
Fix ordering of dev dependencies' specifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ packaging = ">=22,<24"
 
 [tool.poetry.dev-dependencies]
 black = "^23.1"
+mypy = "0.991"
 pylint = [
     { version = "~2.13", python = "<3.7.2" },
     { version = "^2.16", python = "^3.7.2" }
 ]
 pydocstyle = "^6.3"
-mypy = "0.991"
 
 [tool.poetry.scripts]
 templtest = "templtest.cli:main"


### PR DESCRIPTION
Fix of `pyproject.toml` formatting. Fix ordering of development dependencies' specifications.